### PR TITLE
Also ignore invalid escape sequence (W605)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,4 +23,4 @@ jobs:
           pip install -U pip flake8
       - name: Run tests
         run: |
-          flake8 modules --ignore=E501
+          flake8 modules --ignore=E501,W605


### PR DESCRIPTION
Unless these can be fixed (I'm not personally sure how), they should likely be ignored.